### PR TITLE
S10/N10: initial A14 release

### DIFF
--- a/builds/beyond0lte.json
+++ b/builds/beyond0lte.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",

--- a/builds/beyond1lte.json
+++ b/builds/beyond1lte.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",
@@ -15,7 +15,7 @@
       }
     ],
     "device_name": "Samsung Galaxy S10",
-    "device": "beyond1lte",
+    "device": "beyond0lte",
     "xda_thread": "https://forum.xda-developers.com/t/rom-13-0-official-droidx-ui-v1-3-s10-s10-s105g-s10e.4580481/",
     "updater": true
 }

--- a/builds/beyond2lte.json
+++ b/builds/beyond2lte.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",
@@ -15,7 +15,7 @@
       }
     ],
     "device_name": "Samsung Galaxy S10+",
-    "device": "beyond2lte",
+    "device": "beyond0lte",
     "xda_thread": "https://forum.xda-developers.com/t/rom-13-0-official-droidx-ui-v1-3-s10-s10-s105g-s10e.4580481/",
     "updater": true
 }

--- a/builds/beyondx.json
+++ b/builds/beyondx.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",
@@ -15,7 +15,7 @@
       }
     ],
     "device_name": "Samsung Galaxy S10 5G",
-    "device": "beyondx",
+    "device": "beyond0lte",
     "xda_thread": "https://forum.xda-developers.com/t/rom-13-0-official-droidx-ui-v1-3-s10-s10-s105g-s10e.4580481/",
     "updater": true
 }

--- a/builds/d1.json
+++ b/builds/d1.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",

--- a/builds/d2s.json
+++ b/builds/d2s.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",

--- a/builds/d2x.json
+++ b/builds/d2x.json
@@ -1,13 +1,13 @@
 {
-    "BuildingTime": "20230924",
+    "BuildingTime": "20240229",
     "size": [
       {
-        "gapps": "1.4",
-        "vanilla": "0.8"
+        "gapps": "_",
+        "vanilla": "1.0"
       }
     ],
-    "version" : "1.5.3",
-    "last_updated": "24th September 2023",
+    "version" : "2.0",
+    "last_updated": "29th Febuary 2024",
     "maintainer": [
       {
         "name": "MODEDGES",

--- a/changelogs/beyond0lte.md
+++ b/changelogs/beyond0lte.md
@@ -1,17 +1,7 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-# v1.5.3 LimeDust
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
-- some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
-
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
 - some miscellaneous changes.

--- a/changelogs/beyond1lte.md
+++ b/changelogs/beyond1lte.md
@@ -1,17 +1,7 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## Date: 26th-September-2023
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
-- some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
-
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
 - some miscellaneous changes.

--- a/changelogs/beyond2lte.md
+++ b/changelogs/beyond2lte.md
@@ -1,17 +1,8 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## Date: 26th-September-2023
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
 - some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
 
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
-- some miscellaneous changes.

--- a/changelogs/beyondx.md
+++ b/changelogs/beyondx.md
@@ -1,17 +1,7 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## Date: 26th-September-2023
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
-- some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
-
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
 - some miscellaneous changes.

--- a/changelogs/d1.md
+++ b/changelogs/d1.md
@@ -1,17 +1,7 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## Date: 26th-September-2023
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
-- some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
-
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
 - some miscellaneous changes.

--- a/changelogs/d2s.md
+++ b/changelogs/d2s.md
@@ -1,17 +1,7 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## Date: 26th-September-2023
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
-- some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
-
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
 - some miscellaneous changes.

--- a/changelogs/d2x.md
+++ b/changelogs/d2x.md
@@ -1,17 +1,7 @@
 <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## Date: 26th-September-2023
+# v2.0 NewHorizon
 
-- removed some duplicates
+- initial android 14 
 - fixed some kernel errors.
-- some miscellaneous changes.
-- removed some hal features
-- removed doxe and AdvancedDisplay
-- Device Should Not Heat As Much
-- Fixed Some Battery Drainage
-
-## Date: 19-May-2023
-
-- some bugfixes.
-- upstreamed kernel.
 - some miscellaneous changes.

--- a/changelogs/s10-n10.md
+++ b/changelogs/s10-n10.md
@@ -1,8 +1,7 @@
  <img src="https://raw.githubusercontent.com/DroidX-UI-Devices/Official_Devices/13/banners/changelogs.png" />
 
-## 19-May-2023
+# v2.0 NewHorizon
 
-- some bugfixes.
-- upstreamed kernel.
+- initial android 14 
+- fixed some kernel errors.
 - some miscellaneous changes.
-- initial official release.


### PR DESCRIPTION
this release includes

beyond0lte: Samsung Galaxy S10e
beyond1lte: Samsung Galaxy S10
beyond2lte: Samsung Galaxy S10+
beyondx: Samsung Galaxy  S10 5G
d1: Samsung Galaxy Note 10
d2s: Samsung Galaxy Note10+
d2x: Samsung Galaxy Note 10+ 5G